### PR TITLE
Add JWK support to AES

### DIFF
--- a/lib/algorithms/aes.js
+++ b/lib/algorithms/aes.js
@@ -21,7 +21,7 @@ const randomBytes = promisify(randomBytesCallback);
 
 const aesBase = {
   async generateKey(algorithm, extractable, usages) {
-    limitUsages(usages, ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey']);
+    limitUsages(usages, this.allowedUsages);
 
     const { length } = algorithm;
     if (length !== 128 && length !== 192 && length !== 256)
@@ -33,7 +33,7 @@ const aesBase = {
   },
 
   importKey(keyFormat, keyData, params, extractable, keyUsages) {
-    limitUsages(keyUsages, ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey']);
+    limitUsages(keyUsages, this.allowedUsages);
 
     let buf;
     if (keyFormat === 'raw') {
@@ -113,6 +113,7 @@ const aesBase = {
 // Spec: https://www.w3.org/TR/WebCryptoAPI/#aes-ctr
 module.exports.AES_CTR = {
   name: 'AES-CTR',
+  allowedUsages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
   ...aesBase,
 
   _doCipher(iv, length, data, fn) {
@@ -194,6 +195,7 @@ module.exports.AES_CTR = {
 // Spec: https://www.w3.org/TR/WebCryptoAPI/#aes-cbc
 module.exports.AES_CBC = {
   name: 'AES-CBC',
+  allowedUsages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
   ...aesBase,
 
   encrypt(params, key, data) {
@@ -228,6 +230,7 @@ module.exports.AES_CBC = {
 // Spec: https://www.w3.org/TR/WebCryptoAPI/#aes-gcm
 module.exports.AES_GCM = {
   name: 'AES-GCM',
+  allowedUsages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
   ...aesBase,
 
   encrypt(params, key, data) {
@@ -266,6 +269,7 @@ module.exports.AES_GCM = {
 // Spec: https://www.w3.org/TR/WebCryptoAPI/#aes-kw
 module.exports.AES_KW = {
   name: 'AES-KW',
+  allowedUsages: ['wrapKey', 'unwrapKey'],
   ...aesBase,
 
   defaultIV: Buffer.from('A6A6A6A6A6A6A6A6', 'hex'),

--- a/lib/algorithms/aes.js
+++ b/lib/algorithms/aes.js
@@ -8,9 +8,14 @@ const {
 } = require('crypto');
 const { promisify } = require('util');
 
-const { NotSupportedError, OperationError } = require('../errors');
+const { DataError, NotSupportedError, OperationError } = require('../errors');
 const { kKeyMaterial, CryptoKey } = require('../key');
-const { limitUsages, toBuffer } = require('../util');
+const {
+  decodeBase64Url,
+  encodeBase64Url,
+  limitUsages,
+  toBuffer
+} = require('../util');
 
 const randomBytes = promisify(randomBytesCallback);
 
@@ -28,24 +33,73 @@ const aesBase = {
   },
 
   importKey(keyFormat, keyData, params, extractable, keyUsages) {
-    if (keyFormat !== 'raw')
-      throw new NotSupportedError();
-
     limitUsages(keyUsages, ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey']);
 
-    const buf = toBuffer(keyData);
+    let buf;
+    if (keyFormat === 'raw') {
+      buf = toBuffer(keyData);
+    } else if (keyFormat === 'jwk') {
+      if (typeof keyData !== 'object' || keyData === null)
+        throw new DataError();
+
+      const {
+        kty: jwkKty,
+        k: jwkData,
+        alg: jwkAlg,
+        use: jwkUse,
+        key_ops: jwkKeyOps,
+        ext: jwkExt
+      } = keyData;
+
+      if (jwkKty !== 'oct')
+        throw new DataError();
+
+      buf = decodeBase64Url(jwkData);
+
+      if (jwkAlg !== undefined) {
+        if (jwkAlg !== `A${buf.length << 3}${this.name.substr(4)}`)
+          throw new DataError();
+      }
+
+      if (keyUsages.length !== 0 && jwkUse !== undefined && jwkUse !== 'enc')
+        throw new DataError();
+
+      if (jwkKeyOps !== undefined) {
+        if (!Array.isArray(jwkKeyOps))
+          throw new DataError();
+        limitUsages(keyUsages, jwkKeyOps, DataError);
+      }
+
+      if (jwkExt !== undefined && jwkExt === false && extractable) {
+        throw new DataError();
+      }
+    } else {
+      throw new NotSupportedError();
+    }
+
     if (buf.length !== 16 && buf.length !== 24 && buf.length !== 32)
-      throw new OperationError();
+      throw new DataError();
 
     return new CryptoKey('secret', { name: this.name, length: buf.length << 3 },
                          extractable, keyUsages,
-                         createSecretKey(toBuffer(keyData)));
+                         createSecretKey(buf));
   },
 
   exportKey(format, key) {
-    if (format !== 'raw')
+    const buf = key[kKeyMaterial].export();
+    if (format === 'raw') {
+      return buf;
+    } else if (format === 'jwk') {
+      return {
+        kty: 'oct',
+        alg: `A${buf.length << 3}${this.name.substr(4)}`,
+        k: encodeBase64Url(buf),
+        key_ops: key.usages,
+        ext: key.extractable
+      };
+    } else {
       throw new NotSupportedError();
-    return key[kKeyMaterial].export();
+    }
   },
 
   'get key length'(algorithm) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -12,9 +12,13 @@ OperationError.prototype.name = 'OperationError';
 class QuotaExceededError extends Error {}
 QuotaExceededError.prototype.name = 'QuotaExceededError';
 
+class DataError extends Error {}
+DataError.prototype.name = 'DataError';
+
 module.exports = {
   NotSupportedError,
   InvalidAccessError,
   OperationError,
-  QuotaExceededError
+  QuotaExceededError,
+  DataError
 };

--- a/lib/subtle.js
+++ b/lib/subtle.js
@@ -130,7 +130,7 @@ async function unwrapKey(format, wrappedKey, unwrappingKey,
     alg = getAlgorithm(unwrapAlgorithm, unwrapFn = 'decrypt');
   }
 
-  const importAlg = getAlgorithm(unwrappingKey.algorithm, 'importKey');
+  const importAlg = getAlgorithm(unwrappedKeyAlgorithm, 'importKey');
 
   if (unwrappingKey[kAlgorithm].name !== alg.name)
     throw new InvalidAccessError();

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const algorithms = require('./algorithms');
+const { DataError } = require('./errors');
 
 module.exports.toBuffer = (source) => {
   if (ArrayBuffer.isView(source)) {
@@ -15,9 +16,44 @@ module.exports.opensslHashFunctionName = (algorithm) => {
   return algorithms.getAlgorithm(algorithm, op)[op]();
 };
 
-module.exports.limitUsages = (usages, allowed) => {
+module.exports.limitUsages = (usages, allowed, err = SyntaxError) => {
   for (const usage of usages) {
     if (!allowed.includes(usage))
-      throw new SyntaxError();
+      throw new err();
   }
+};
+
+// Variant of base64 encoding as described in
+// https://tools.ietf.org/html/rfc4648#section-5
+module.exports.decodeBase64Url = (enc) => {
+  if (typeof enc !== 'string')
+    throw new DataError();
+
+  enc = enc.split('').map((c) => {
+    switch (c) {
+      case '-':
+        return '+';
+      case '_':
+        return '/';
+      default:
+        return c;
+    }
+  }).join('');
+
+  return Buffer.from(enc, 'base64');
+};
+
+module.exports.encodeBase64Url = (enc) => {
+  return enc.toString('base64').split('').map((c) => {
+    switch (c) {
+      case '+':
+        return '-';
+      case '/':
+        return '_';
+      case '=':
+        return '';
+      default:
+        return c;
+    }
+  }).join('');
 };

--- a/test/algorithms/aes.js
+++ b/test/algorithms/aes.js
@@ -9,16 +9,16 @@ function twice(buf) {
   return Buffer.concat([buf, buf], buf.length * 2);
 }
 
-function testGenImportExport(name) {
+function testGenImportExport(name, keyUsages) {
   return async () => {
     const key1 = await subtle.generateKey({ name, length: 192 }, true,
-                                          ['encrypt', 'decrypt']);
+                                          keyUsages);
     assert.strictEqual(key1.algorithm.name, name);
     const key2 = await subtle.generateKey({ name, length: 192 }, true,
-                                          ['encrypt', 'decrypt']);
+                                          keyUsages);
     assert.strictEqual(key2.algorithm.name, name);
     const key3 = await subtle.generateKey({ name, length: 256 }, true,
-                                          ['encrypt', 'decrypt']);
+                                          keyUsages);
     assert.strictEqual(key3.algorithm.name, name);
 
     const expKey1 = await subtle.exportKey('raw', key1);
@@ -34,11 +34,11 @@ function testGenImportExport(name) {
     assert.notDeepStrictEqual(expKey1, expKey2);
 
     const impKey1 = await subtle.importKey('raw', expKey1, name, true,
-                                           ['encrypt', 'decrypt']);
+                                           keyUsages);
     const impKey2 = await subtle.importKey('raw', expKey2, name, true,
-                                           ['encrypt', 'decrypt']);
+                                           keyUsages);
     const impKey3 = await subtle.importKey('raw', expKey3, name, true,
-                                           ['encrypt', 'decrypt']);
+                                           keyUsages);
 
     assert.deepStrictEqual(await subtle.exportKey('raw', impKey1), expKey1);
     assert.deepStrictEqual(await subtle.exportKey('raw', impKey2), expKey2);
@@ -46,10 +46,10 @@ function testGenImportExport(name) {
   };
 }
 
-function testJsonWebKeys(algorithmName, jwkAlgorithmSuffix) {
+function testJsonWebKeys(algorithmName, jwkAlgorithmSuffix, keyUsages) {
   async function test(jwk, hexKey, length) {
     const key = await subtle.importKey('jwk', jwk, algorithmName, true,
-                                       ['encrypt', 'decrypt']);
+                                       keyUsages);
     assert.strictEqual(key.algorithm.name, algorithmName);
     assert.strictEqual(key.algorithm.length, length);
 
@@ -66,7 +66,7 @@ function testJsonWebKeys(algorithmName, jwkAlgorithmSuffix) {
         alg: `A128${jwkAlgorithmSuffix}`,
         k: 'GawgguFyGrWKav7AX4VKUg',
         ext: true,
-        key_ops: ['encrypt', 'decrypt']
+        key_ops: keyUsages
       }, '19ac2082e1721ab58a6afec05f854a52', 128),
 
       // Generated in Mozilla Firefox.
@@ -74,7 +74,7 @@ function testJsonWebKeys(algorithmName, jwkAlgorithmSuffix) {
         alg: `A192${jwkAlgorithmSuffix}`,
         ext: true,
         k: 'bOHt12k8byt-XKHo9kXY_1skBP10eJGC',
-        key_ops: ['encrypt', 'decrypt'],
+        key_ops: keyUsages,
         kty: 'oct'
       }, '6ce1edd7693c6f2b7e5ca1e8f645d8ff5b2404fd74789182', 192)
     ]);
@@ -83,10 +83,10 @@ function testJsonWebKeys(algorithmName, jwkAlgorithmSuffix) {
 
 describe('AES-CTR', () => {
   it('should generate, import and export keys',
-     testGenImportExport('AES-CTR'));
+     testGenImportExport('AES-CTR', ['encrypt', 'decrypt']));
 
   it('should support JWK import and export',
-     testJsonWebKeys('AES-CTR', 'CTR'));
+     testJsonWebKeys('AES-CTR', 'CTR', ['encrypt', 'decrypt']));
 
   it('should encrypt and decrypt', async () => {
     const keyData = Buffer.from('36adfe538cc234279e4cbb29e1f27af5', 'hex');
@@ -161,10 +161,10 @@ describe('AES-CTR', () => {
 
 describe('AES-CBC', () => {
   it('should generate, import and export keys',
-     testGenImportExport('AES-CBC'));
+     testGenImportExport('AES-CBC', ['encrypt', 'decrypt']));
 
   it('should support JWK import and export',
-     testJsonWebKeys('AES-CBC', 'CBC'));
+     testJsonWebKeys('AES-CBC', 'CBC', ['encrypt', 'decrypt']));
 
   it('should encrypt and decrypt', async () => {
     const keyData = Buffer.from('36adfe538cc234279e4cbb29e1f27af5', 'hex');
@@ -192,10 +192,10 @@ describe('AES-CBC', () => {
 
 describe('AES-GCM', () => {
   it('should generate, import and export keys',
-     testGenImportExport('AES-GCM'));
+     testGenImportExport('AES-GCM', ['encrypt', 'decrypt']));
 
   it('should support JWK import and export',
-     testJsonWebKeys('AES-GCM', 'GCM'));
+     testJsonWebKeys('AES-GCM', 'GCM', ['encrypt', 'decrypt']));
 
   it('should encrypt and decrypt', async () => {
     const keyData = Buffer.from('36adfe538cc234279e4cbb29e1f27af5', 'hex');
@@ -273,10 +273,10 @@ describe('AES-GCM', () => {
 
 describe('AES-KW', () => {
   it('should generate, import and export keys',
-     testGenImportExport('AES-KW'));
+     testGenImportExport('AES-KW', ['wrapKey', 'unwrapKey']));
 
   it('should support JWK import and export',
-     testJsonWebKeys('AES-KW', 'KW'));
+     testJsonWebKeys('AES-KW', 'KW', ['wrapKey', 'unwrapKey']));
 
   it('should wrap and unwrap keys', async () => {
     const wrappingKey = await subtle.generateKey({


### PR DESCRIPTION
This adds support for the `jwk` key format when importing and exporting AES keys. This is specified in different places in the WebCrypto spec (once per AES algorithm), the first relevant section is [25.7](https://www.w3.org/TR/WebCryptoAPI/#aes-ctr-operations).