### PR TITLE
ci: add github-actions ci lint, coverage and nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm install
+      - run: npm run lint
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 12.11.0 # minimal version
+          - 12 # v12.x
+          - 13.0.0
+          - 13
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run coverage
+
+  test-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: npm run coverage
+        run: |
+          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+          export NVM_DIR=~/.nvm
+          source ~/.nvm/nvm.sh
+          NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/ nvm install node
+          npm install
+          npm run coverage


### PR DESCRIPTION
Adds [Github Actions](https://github.com/features/actions) CI with the following jobs

- lint
- test matrix on all actions-available platforms + minimal and current node versions
- test on nightly

[example run](https://github.com/panva/webcrypto/commit/0a09e9f0f721a549111ff12aec5599ae3d39a53e/checks)