### PR TITLE
Add RSA-OAEP prototype

### DIFF
--- a/lib/algorithms.js
+++ b/lib/algorithms.js
@@ -5,7 +5,7 @@ const { ECDSA } = require('./algorithms/ecdsa');
 const { HKDF } = require('./algorithms/hkdf');
 const { HMAC } = require('./algorithms/hmac');
 const { PBKDF2 } = require('./algorithms/pbkdf2');
-const { RSASSA_PKCS1, RSA_PSS } = require('./algorithms/rsa');
+const { RSASSA_PKCS1, RSA_PSS, RSA_OAEP } = require('./algorithms/rsa');
 const { SHA_1, SHA_256, SHA_384, SHA_512 } = require('./algorithms/sha');
 const { NotSupportedError } = require('./errors');
 
@@ -25,6 +25,7 @@ const algorithms = [
 
   RSASSA_PKCS1,
   RSA_PSS,
+  RSA_OAEP,
 
   SHA_1,
   SHA_256,

--- a/lib/algorithms/rsa.js
+++ b/lib/algorithms/rsa.js
@@ -165,3 +165,23 @@ module.exports.RSA_PSS = {
     }, signature);
   }
 };
+
+// Spec: https://www.w3.org/TR/WebCryptoAPI/#rsa-oaep
+module.exports.RSA_OAEP = {
+  name: 'RSA-OAEP',
+  ...rsaBase,
+
+  encrypt(params, key, data) {
+    return crypto.publicEncrypt({
+      key: key[kKeyMaterial],
+      oaepHash: opensslHashFunctionName(key.algorithm.hash.name)
+    }, data);
+  },
+
+  decrypt(params, key, data) {
+    return crypto.privateDecrypt({
+      key: key[kKeyMaterial],
+      oaepHash: opensslHashFunctionName(key.algorithm.hash.name)
+    }, data);
+  }
+};


### PR DESCRIPTION
This adds very rudimentary support for RSA-OAEP, apart from JWK and the `label` option.

Fixes: https://github.com/nodejs/webcrypto/issues/5