### PR TITLE
Validate TypedArray type in getRandomValues

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -15,10 +15,14 @@ QuotaExceededError.prototype.name = 'QuotaExceededError';
 class DataError extends Error {}
 DataError.prototype.name = 'DataError';
 
+class TypeMismatchError extends Error {}
+TypeMismatchError.prototype.name = 'TypeMismatchError';
+
 module.exports = {
   NotSupportedError,
   InvalidAccessError,
   OperationError,
   QuotaExceededError,
-  DataError
+  DataError,
+  TypeMismatchError
 };

--- a/lib/random.js
+++ b/lib/random.js
@@ -2,10 +2,23 @@
 
 const { randomFillSync } = require('crypto');
 
-const { QuotaExceededError } = require('./errors');
+const { QuotaExceededError, TypeMismatchError } = require('./errors');
+
+function isIntegerTypedArray(o) {
+  return o instanceof Int8Array ||
+         o instanceof Uint8Array ||
+         o instanceof Int16Array ||
+         o instanceof Uint16Array ||
+         o instanceof Int32Array ||
+         o instanceof Uint32Array ||
+         o instanceof Uint8ClampedArray;
+}
 
 // Spec: https://www.w3.org/TR/WebCryptoAPI/#dfn-Crypto-method-getRandomValues
 module.exports.getRandomValues = (array) => {
+  if (!isIntegerTypedArray(array))
+    throw new TypeMismatchError();
+
   if (array.byteLength > 65536)
     throw new QuotaExceededError();
 

--- a/test/wpt/wpt-runner.js
+++ b/test/wpt/wpt-runner.js
@@ -118,7 +118,17 @@ async function runTest(test) {
     },
     btoa(data) {
       return Buffer.from(data, 'binary').toString('base64');
-    }
+    },
+
+    Int8Array,
+    Uint8Array,
+    Int16Array,
+    Uint16Array,
+    Int32Array,
+    Uint32Array,
+    Uint8ClampedArray,
+    Float32Array,
+    Float64Array
   };
 
   sandbox.self = sandbox;


### PR DESCRIPTION
`getRandomValues` should only accept integer-based `TypedArray`s.