### PR TITLE
Throw OperationError if PBKDF2 iterations is zero

### DIFF
--- a/lib/algorithms/pbkdf2.js
+++ b/lib/algorithms/pbkdf2.js
@@ -18,6 +18,9 @@ module.exports.PBKDF2 = {
 
     const hashFn = opensslHashFunctionName(hash);
 
+    if (iterations === 0)
+      throw new OperationError();
+
     const keyDerivationKey = key[kKeyMaterial];
     return new Promise((resolve, reject) => {
       pbkdf2(keyDerivationKey, salt, iterations, length, hashFn, (err, key) => {


### PR DESCRIPTION
Node.js accepts an iteration count of zero, but WebCrypto requires an `OperationError`. This fixes 468 WPTs.