### PR TITLE
Improve error handling in AES algorithm

### DIFF
--- a/lib/algorithms/aes.js
+++ b/lib/algorithms/aes.js
@@ -223,7 +223,11 @@ module.exports.AES_CBC = {
     const cipher = `aes-${secretKey.symmetricKeySize << 3}-cbc`;
 
     const c = createDecipheriv(cipher, secretKey, iv);
-    return Buffer.concat([c.update(data), c.final()]);
+    try {
+      return Buffer.concat([c.update(data), c.final()]);
+    } catch (err) {
+      throw new OperationError(err.message);
+    }
   }
 };
 
@@ -240,11 +244,18 @@ module.exports.AES_GCM = {
     const secretKey = key[kKeyMaterial];
     const cipher = `aes-${secretKey.symmetricKeySize << 3}-gcm`;
 
+    if (tagLength !== undefined && tagLength % 8 !== 0)
+      throw new OperationError();
+
     const authTagLength = tagLength === undefined ? 16 : tagLength >> 3;
-    const c = createCipheriv(cipher, secretKey, ivBuf, { authTagLength });
-    if (additionalData !== undefined)
-      c.setAAD(additionalData);
-    return Buffer.concat([c.update(data), c.final(), c.getAuthTag()]);
+    try {
+      const c = createCipheriv(cipher, secretKey, ivBuf, { authTagLength });
+      if (additionalData !== undefined)
+        c.setAAD(additionalData);
+      return Buffer.concat([c.update(data), c.final(), c.getAuthTag()]);
+    } catch (err) {
+      throw new OperationError(err.message);
+    }
   },
 
   decrypt(params, key, data) {
@@ -254,15 +265,22 @@ module.exports.AES_GCM = {
     const secretKey = key[kKeyMaterial];
     const cipher = `aes-${secretKey.symmetricKeySize << 3}-gcm`;
 
+    if (tagLength !== undefined && tagLength % 8 !== 0)
+      throw new OperationError();
+
     const authTagLength = tagLength === undefined ? 16 : tagLength >> 3;
-    const c = createDecipheriv(cipher, secretKey, ivBuf, { authTagLength });
-    if (additionalData !== undefined)
-      c.setAAD(additionalData);
-    c.setAuthTag(data.slice(data.byteLength - authTagLength, data.length));
-    return Buffer.concat([
-      c.update(data.slice(0, data.byteLength - authTagLength)),
-      c.final()
-    ]);
+    try {
+      const c = createDecipheriv(cipher, secretKey, ivBuf, { authTagLength });
+      if (additionalData !== undefined)
+        c.setAAD(additionalData);
+      c.setAuthTag(data.slice(data.byteLength - authTagLength, data.length));
+      return Buffer.concat([
+        c.update(data.slice(0, data.byteLength - authTagLength)),
+        c.final()
+      ]);
+    } catch (err) {
+      throw new OperationError(err.message);
+    }
   }
 };
 


### PR DESCRIPTION
If an AES operation can fail, the error should be wrapped into an `OperationError`.