### PR TITLE
Don't throw if ECDSA signature is invalid

### DIFF
--- a/lib/algorithms/ecdsa.js
+++ b/lib/algorithms/ecdsa.js
@@ -7,8 +7,7 @@ const { curveInfo } = require('../curves');
 const {
   DataError,
   InvalidAccessError,
-  NotSupportedError,
-  OperationError
+  NotSupportedError
 } = require('../errors');
 const { kKeyMaterial, CryptoKey } = require('../key');
 const { limitUsages, opensslHashFunctionName, toBuffer } = require('../util');
@@ -19,7 +18,7 @@ const byte = (b) => Buffer.from([b]);
 
 function convertSignatureToASN1(signature, n) {
   if (signature.length !== 2 * n)
-    throw new OperationError();
+    return undefined;
 
   const r = signature.slice(0, n);
   const s = signature.slice(n);
@@ -195,6 +194,8 @@ module.exports.ECDSA = {
 
     const n = curveInfo[key.algorithm.namedCurve].basePointOrderSize;
     signature = convertSignatureToASN1(toBuffer(signature), n);
+    if (signature === undefined)
+      return false;
 
     const { hash } = algorithm;
     const hashFn = opensslHashFunctionName(hash);


### PR DESCRIPTION
If an ECDSA signature has an invalid length, verification should return `false` instead of throwing an error.