### PR TITLE
Implement 'get key length' in HMAC/HKDF/PBKDF2

### DIFF
--- a/lib/algorithms/hkdf.js
+++ b/lib/algorithms/hkdf.js
@@ -53,5 +53,9 @@ module.exports.HKDF = {
 
     return new CryptoKey('secret', { name: 'HKDF' }, extractable, keyUsages,
                          Buffer.from(keyData));
+  },
+
+  'get key length'() {
+    return null;
   }
 };

--- a/lib/algorithms/hmac.js
+++ b/lib/algorithms/hmac.js
@@ -156,5 +156,15 @@ module.exports.HMAC = {
     } else {
       throw new NotSupportedError();
     }
+  },
+
+  'get key length'(algorithm) {
+    const { length } = algorithm;
+    if (length === undefined)
+      return getHashBlockSize(algorithm.hash.name);
+    else if (length === 0)
+      throw new TypeError();
+    else
+      return length;
   }
 };

--- a/lib/algorithms/pbkdf2.js
+++ b/lib/algorithms/pbkdf2.js
@@ -42,5 +42,9 @@ module.exports.PBKDF2 = {
 
     return new CryptoKey('secret', { name: 'PBKDF2' }, extractable, keyUsages,
                          Buffer.from(keyData));
+  },
+
+  'get key length'() {
+    return null;
   }
 };


### PR DESCRIPTION
This patch is required for spec compliance and fixes 1392 WPTs.