### PR TITLE
Begin working on WebIDL conformity

### DIFF
--- a/lib/algorithms.js
+++ b/lib/algorithms.js
@@ -9,6 +9,7 @@ const { PBKDF2 } = require('./algorithms/pbkdf2');
 const { RSASSA_PKCS1, RSA_PSS, RSA_OAEP } = require('./algorithms/rsa');
 const { SHA_1, SHA_256, SHA_384, SHA_512 } = require('./algorithms/sha');
 const { NotSupportedError } = require('./errors');
+const { requireDOMString } = require('./idl');
 
 const algorithms = [
   AES_CTR,
@@ -70,15 +71,11 @@ const supportedAlgorithms = objectFromArray([
 });
 
 function getAlgorithm(alg, op) {
-  if (typeof alg !== 'string') {
-    if (typeof alg !== 'object')
-      throw new SyntaxError();
-    const { name } = alg;
-    if (typeof name !== 'string')
-      throw new SyntaxError();
+  if (typeof alg === 'object') {
     return getAlgorithm(alg.name, op);
   }
 
+  requireDOMString(alg);
   const impl = supportedAlgorithms[op][alg.toLowerCase()];
   if (impl === undefined)
     throw new NotSupportedError();

--- a/lib/algorithms/aes.js
+++ b/lib/algorithms/aes.js
@@ -9,6 +9,7 @@ const {
 const { promisify } = require('util');
 
 const { DataError, NotSupportedError, OperationError } = require('../errors');
+const { toOctetEnforceRange, toUnsignedShortEnforceRange } = require('../idl');
 const { kKeyMaterial, CryptoKey } = require('../key');
 const {
   decodeBase64Url,
@@ -23,7 +24,7 @@ const aesBase = {
   async generateKey(algorithm, extractable, usages) {
     limitUsages(usages, this.allowedUsages);
 
-    const { length } = algorithm;
+    const length = toUnsignedShortEnforceRange(algorithm.length);
     if (length !== 128 && length !== 192 && length !== 256)
       throw new OperationError();
 
@@ -103,7 +104,8 @@ const aesBase = {
   },
 
   'get key length'(algorithm) {
-    const { length } = algorithm;
+    let { length } = algorithm;
+    length = toUnsignedShortEnforceRange(length);
     if (length !== 128 && length !== 192 && length !== 256)
       throw new OperationError();
     return length;
@@ -156,7 +158,8 @@ module.exports.AES_CTR = {
   },
 
   encrypt(params, key, data) {
-    const { counter, length } = params;
+    const { counter } = params;
+    const length = toOctetEnforceRange(params.length);
 
     const iv = toBuffer(counter);
     if (iv.length !== 16)
@@ -174,7 +177,8 @@ module.exports.AES_CTR = {
   },
 
   decrypt(params, key, data) {
-    const { counter, length } = params;
+    const { counter } = params;
+    const length = toOctetEnforceRange(params.length);
 
     const iv = toBuffer(counter);
     if (iv.length !== 16)

--- a/lib/algorithms/ecdh.js
+++ b/lib/algorithms/ecdh.js
@@ -9,6 +9,7 @@ const {
   OperationError,
   NotSupportedError
 } = require('../errors');
+const { requireDOMString } = require('../idl');
 const { kKeyMaterial, CryptoKey } = require('../key');
 const {
   decodeBase64Url,
@@ -22,6 +23,7 @@ module.exports.ECDH = {
 
   async generateKey(algorithm, extractable, usages) {
     const { namedCurve } = algorithm;
+    requireDOMString(namedCurve);
 
     const curve = curveInfo[namedCurve];
     if (!curve)
@@ -46,6 +48,7 @@ module.exports.ECDH = {
 
   importKey(keyFormat, keyData, params, extractable, keyUsages) {
     const { namedCurve } = params;
+    requireDOMString(namedCurve);
 
     const curve = curveInfo[namedCurve];
     if (!curve)

--- a/lib/algorithms/ecdsa.js
+++ b/lib/algorithms/ecdsa.js
@@ -9,6 +9,7 @@ const {
   InvalidAccessError,
   NotSupportedError
 } = require('../errors');
+const { requireDOMString } = require('../idl');
 const { kKeyMaterial, CryptoKey } = require('../key');
 const { limitUsages, opensslHashFunctionName, toBuffer } = require('../util');
 
@@ -115,6 +116,7 @@ module.exports.ECDSA = {
     const publicUsages = usages.includes('verify') ? ['verify'] : [];
 
     const { namedCurve } = algorithm;
+    requireDOMString(namedCurve);
     if (!curveInfo[namedCurve])
       throw new NotSupportedError();
 
@@ -137,6 +139,7 @@ module.exports.ECDSA = {
 
   importKey(keyFormat, keyData, params, extractable, keyUsages) {
     const { namedCurve } = params;
+    requireDOMString(namedCurve);
 
     const opts = {
       key: toBuffer(keyData),

--- a/lib/algorithms/hmac.js
+++ b/lib/algorithms/hmac.js
@@ -9,6 +9,7 @@ const { promisify } = require('util');
 
 const algorithms = require('../algorithms');
 const { DataError, NotSupportedError } = require('../errors');
+const { toUnsignedLongEnforceRange } = require('../idl');
 const { kKeyMaterial, CryptoKey } = require('../key');
 const {
   decodeBase64Url,
@@ -44,6 +45,8 @@ module.exports.HMAC = {
 
   async generateKey(algorithm, extractable, usages) {
     let { length } = algorithm;
+    if (length !== undefined)
+      length = toUnsignedLongEnforceRange(length);
 
     limitUsages(usages, ['sign', 'verify']);
 
@@ -67,6 +70,8 @@ module.exports.HMAC = {
 
   importKey(keyFormat, keyData, params, extractable, keyUsages) {
     let { length } = params;
+    if (length !== undefined)
+      length = toUnsignedLongEnforceRange(length);
 
     limitUsages(keyUsages, ['sign', 'verify']);
 
@@ -165,6 +170,6 @@ module.exports.HMAC = {
     else if (length === 0)
       throw new TypeError();
     else
-      return length;
+      return toUnsignedLongEnforceRange(length);
   }
 };

--- a/lib/algorithms/pbkdf2.js
+++ b/lib/algorithms/pbkdf2.js
@@ -3,6 +3,7 @@
 const { pbkdf2 } = require('crypto');
 
 const { OperationError, NotSupportedError } = require('../errors');
+const { toUnsignedLongEnforceRange } = require('../idl');
 const { kKeyMaterial, CryptoKey } = require('../key');
 const { limitUsages, opensslHashFunctionName } = require('../util');
 
@@ -10,9 +11,10 @@ module.exports.PBKDF2 = {
   name: 'PBKDF2',
 
   deriveBits(params, key, length) {
-    const { hash, salt, iterations } = params;
+    const { hash, salt } = params;
+    const iterations = toUnsignedLongEnforceRange(params.iterations);
 
-    if (length === null || length === 0 || length % 8 !== 0)
+    if (length === 0 || length % 8 !== 0)
       throw new OperationError();
     length >>= 3;
 

--- a/lib/algorithms/rsa.js
+++ b/lib/algorithms/rsa.js
@@ -10,6 +10,7 @@ const {
   OperationError
 } = require('../errors');
 const { kKeyMaterial, CryptoKey } = require('../key');
+const { toUnsignedLongEnforceRange } = require('../idl');
 const { limitUsages, opensslHashFunctionName, toBuffer } = require('../util');
 
 const generateKeyPair = promisify(crypto.generateKeyPair);
@@ -50,9 +51,9 @@ const rsaBase = {
 
     const {
       hash: hashAlg,
-      modulusLength,
       publicExponent: rawPublicExponent
     } = algorithm;
+    const modulusLength = toUnsignedLongEnforceRange(algorithm.modulusLength);
 
     const hash = {
       name: algorithms.getAlgorithm(hashAlg, 'digest').name
@@ -145,7 +146,8 @@ module.exports.RSA_PSS = {
   ...rsaBase,
 
   sign(algorithm, key, data) {
-    const { saltLength } = algorithm;
+    let { saltLength } = algorithm;
+    saltLength = toUnsignedLongEnforceRange(saltLength);
 
     const hashFn = opensslHashFunctionName(key.algorithm.hash);
     return crypto.sign(hashFn, toBuffer(data), {
@@ -156,7 +158,8 @@ module.exports.RSA_PSS = {
   },
 
   verify(algorithm, key, signature, data) {
-    const { saltLength } = algorithm;
+    let { saltLength } = algorithm;
+    saltLength = toUnsignedLongEnforceRange(saltLength);
 
     const hashFn = opensslHashFunctionName(key.algorithm.hash);
     return crypto.verify(hashFn, toBuffer(data), {

--- a/lib/idl.js
+++ b/lib/idl.js
@@ -1,0 +1,50 @@
+'use strict';
+
+function toBoolean(x) {
+  return !!x;
+}
+
+function toOctetEnforceRange(x) {
+  x = +x;
+  if (Number.isNaN(x) || x < 0 || x > 0xff)
+    throw new TypeError();
+  return x >>> 0;
+}
+
+function toUnsignedLong(x) {
+  return x >>> 0;
+}
+
+function toUnsignedLongEnforceRange(x) {
+  x = +x;
+  if (Number.isNaN(x) || x < 0 || x > 0xffffffff)
+    throw new TypeError();
+  return x >>> 0;
+}
+
+function toUnsignedShort(x) {
+  return (x >>> 0) & 0xffff;
+}
+
+function toUnsignedShortEnforceRange(x) {
+  x = +x;
+  if (Number.isNaN(x) || x < 0 || x > 0xffff)
+    throw new TypeError();
+  return x >>> 0;
+}
+
+function requireDOMString(x) {
+  if (typeof x !== 'string')
+    throw new TypeError();
+}
+
+module.exports = {
+  toBoolean,
+  toOctetEnforceRange,
+  toUnsignedLong,
+  toUnsignedLongEnforceRange,
+  toUnsignedShort,
+  toUnsignedShortEnforceRange,
+
+  requireDOMString
+};

--- a/lib/subtle.js
+++ b/lib/subtle.js
@@ -2,6 +2,7 @@
 
 const { getAlgorithm } = require('./algorithms');
 const { InvalidAccessError } = require('./errors');
+const { toBoolean, toUnsignedLong } = require('./idl');
 const { kAlgorithm, kExtractable, requireKeyUsage } = require('./key');
 const { toBuffer } = require('./util');
 
@@ -56,6 +57,8 @@ async function digest(algorithm, data) {
 
 // Spec: https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-generateKey
 async function generateKey(algorithm, extractable, keyUsages) {
+  extractable = toBoolean(extractable);
+
   const alg = getAlgorithm(algorithm, 'generateKey');
   return alg.generateKey(algorithm, extractable, keyUsages);
 }
@@ -63,6 +66,8 @@ async function generateKey(algorithm, extractable, keyUsages) {
 // Spec: https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-deriveKey
 async function deriveKey(algorithm, baseKey, derivedKeyType, extractable,
                          keyUsages) {
+  extractable = toBoolean(extractable);
+
   const alg = getAlgorithm(algorithm, 'deriveBits');
   if (alg.name !== baseKey[kAlgorithm].name)
     throw new InvalidAccessError();
@@ -77,6 +82,8 @@ async function deriveKey(algorithm, baseKey, derivedKeyType, extractable,
 
 // Spec: https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-deriveBits
 async function deriveBits(algorithm, key, length) {
+  length = toUnsignedLong(length);
+
   const alg = getAlgorithm(algorithm, 'deriveBits');
   if (alg.name !== key[kAlgorithm].name)
     throw new InvalidAccessError();
@@ -88,6 +95,7 @@ async function deriveBits(algorithm, key, length) {
 // Spec: https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-importKey
 async function importKey(keyFormat, keyData, algorithm, extractable,
                          keyUsages) {
+  extractable = toBoolean(extractable);
   const alg = getAlgorithm(algorithm, 'importKey');
   return alg.importKey(keyFormat, keyData, algorithm, extractable, keyUsages);
 }
@@ -129,6 +137,8 @@ async function wrapKey(format, key, wrappingKey, wrapAlgorithm) {
 async function unwrapKey(format, wrappedKey, unwrappingKey,
                          unwrapAlgorithm, unwrappedKeyAlgorithm,
                          extractable, keyUsages) {
+  extractable = toBoolean(extractable);
+
   let unwrapFn, alg;
   try {
     alg = getAlgorithm(unwrapAlgorithm, unwrapFn = 'unwrapKey');

--- a/test/unit/algorithms/ecdsa.js
+++ b/test/unit/algorithms/ecdsa.js
@@ -29,10 +29,12 @@ describe('ECDSA', () => {
 
     const impPublicKey = await subtle.importKey('spki', expPublicKey, {
       name: 'ECDSA',
+      namedCurve: 'P-256',
       hash: 'SHA-384'
     }, true, ['verify']);
     const impPrivateKey = await subtle.importKey('pkcs8', expPrivateKey, {
       name: 'ECDSA',
+      namedCurve: 'P-256',
       hash: 'SHA-384'
     }, true, ['sign']);
 

--- a/test/unit/algorithms/rsa.js
+++ b/test/unit/algorithms/rsa.js
@@ -168,7 +168,10 @@ describe('RSA-PSS', () => {
                           'f97b2303a0c6f23ebc6a497c5b6de813d26699bda4bdc65abf' +
                           '657c08b840a6';
     const signature = Buffer.from(signatureData, 'hex');
-    const ok = await subtle.verify('RSA-PSS', publicKey, signature, data);
+    const ok = await subtle.verify({
+      name: 'RSA-PSS',
+      saltLength: 20
+    }, publicKey, signature, data);
     assert.strictEqual(ok, true);
   });
 });


### PR DESCRIPTION
This changes the way we retrieve algorithm and operation parameters to better align with the WebIDL standard. Since WebCrypto uses that standard, we have to integrate all the terrible things, e.g., accepting the empty string `''` and the value `null` as synonyms for the integer `0`.