### PR TITLE
Make BufferSource input validation stricter

### DIFF
--- a/lib/algorithms/aes.js
+++ b/lib/algorithms/aes.js
@@ -9,13 +9,16 @@ const {
 const { promisify } = require('util');
 
 const { DataError, NotSupportedError, OperationError } = require('../errors');
-const { toOctetEnforceRange, toUnsignedShortEnforceRange } = require('../idl');
+const {
+  bufferFromBufferSource,
+  toOctetEnforceRange,
+  toUnsignedShortEnforceRange
+} = require('../idl');
 const { kKeyMaterial, CryptoKey } = require('../key');
 const {
   decodeBase64Url,
   encodeBase64Url,
-  limitUsages,
-  toBuffer
+  limitUsages
 } = require('../util');
 
 const randomBytes = promisify(randomBytesCallback);
@@ -38,7 +41,7 @@ const aesBase = {
 
     let buf;
     if (keyFormat === 'raw') {
-      buf = toBuffer(keyData);
+      buf = bufferFromBufferSource(keyData);
     } else if (keyFormat === 'jwk') {
       if (typeof keyData !== 'object' || keyData === null)
         throw new DataError();
@@ -161,7 +164,7 @@ module.exports.AES_CTR = {
     const { counter } = params;
     const length = toOctetEnforceRange(params.length);
 
-    const iv = toBuffer(counter);
+    const iv = bufferFromBufferSource(counter);
     if (iv.length !== 16)
       throw new OperationError();
 
@@ -180,7 +183,7 @@ module.exports.AES_CTR = {
     const { counter } = params;
     const length = toOctetEnforceRange(params.length);
 
-    const iv = toBuffer(counter);
+    const iv = bufferFromBufferSource(counter);
     if (iv.length !== 16)
       throw new OperationError();
 
@@ -205,7 +208,7 @@ module.exports.AES_CBC = {
   encrypt(params, key, data) {
     let { iv } = params;
 
-    iv = toBuffer(iv);
+    iv = bufferFromBufferSource(iv);
     if (iv.length !== 16)
       throw new OperationError();
 
@@ -219,7 +222,7 @@ module.exports.AES_CBC = {
   decrypt(params, key, data) {
     let { iv } = params;
 
-    iv = toBuffer(iv);
+    iv = bufferFromBufferSource(iv);
     if (iv.length !== 16)
       throw new OperationError();
 
@@ -244,7 +247,7 @@ module.exports.AES_GCM = {
   encrypt(params, key, data) {
     const { iv, tagLength, additionalData } = params;
 
-    const ivBuf = toBuffer(iv);
+    const ivBuf = bufferFromBufferSource(iv);
     const secretKey = key[kKeyMaterial];
     const cipher = `aes-${secretKey.symmetricKeySize << 3}-gcm`;
 
@@ -265,7 +268,7 @@ module.exports.AES_GCM = {
   decrypt(params, key, data) {
     const { iv, tagLength, additionalData } = params;
 
-    const ivBuf = toBuffer(iv);
+    const ivBuf = bufferFromBufferSource(iv);
     const secretKey = key[kKeyMaterial];
     const cipher = `aes-${secretKey.symmetricKeySize << 3}-gcm`;
 

--- a/lib/algorithms/ecdh.js
+++ b/lib/algorithms/ecdh.js
@@ -9,13 +9,12 @@ const {
   OperationError,
   NotSupportedError
 } = require('../errors');
-const { requireDOMString } = require('../idl');
+const { bufferFromBufferSource, requireDOMString } = require('../idl');
 const { kKeyMaterial, CryptoKey } = require('../key');
 const {
   decodeBase64Url,
   encodeBase64Url,
-  limitUsages,
-  toBuffer
+  limitUsages
 } = require('../util');
 
 module.exports.ECDH = {
@@ -57,7 +56,7 @@ module.exports.ECDH = {
     let data, type;
     if (keyFormat === 'raw') {
       limitUsages(keyUsages, []);
-      data = toBuffer(keyData);
+      data = bufferFromBufferSource(keyData);
       if (data.byteLength !== 1 + 2 * curve.basePointOrderSize)
         throw new DataError();
       type = 'public';

--- a/lib/algorithms/ecdsa.js
+++ b/lib/algorithms/ecdsa.js
@@ -9,9 +9,12 @@ const {
   InvalidAccessError,
   NotSupportedError
 } = require('../errors');
-const { requireDOMString } = require('../idl');
+const {
+  bufferFromBufferSource,
+  requireDOMString
+} = require('../idl');
 const { kKeyMaterial, CryptoKey } = require('../key');
-const { limitUsages, opensslHashFunctionName, toBuffer } = require('../util');
+const { limitUsages, opensslHashFunctionName } = require('../util');
 
 const generateKeyPair = promisify(crypto.generateKeyPair);
 
@@ -142,7 +145,7 @@ module.exports.ECDSA = {
     requireDOMString(namedCurve);
 
     const opts = {
-      key: toBuffer(keyData),
+      key: bufferFromBufferSource(keyData),
       format: 'der',
       type: keyFormat
     };
@@ -186,7 +189,8 @@ module.exports.ECDSA = {
     const { hash } = algorithm;
     const hashFn = opensslHashFunctionName(hash);
 
-    const asn1Sig = crypto.sign(hashFn, toBuffer(data), key[kKeyMaterial]);
+    const dataBuffer = bufferFromBufferSource(data);
+    const asn1Sig = crypto.sign(hashFn, dataBuffer, key[kKeyMaterial]);
     const n = curveInfo[key.algorithm.namedCurve].basePointOrderSize;
     return convertSignatureFromASN1(asn1Sig, n);
   },
@@ -196,7 +200,7 @@ module.exports.ECDSA = {
       throw new InvalidAccessError();
 
     const n = curveInfo[key.algorithm.namedCurve].basePointOrderSize;
-    signature = convertSignatureToASN1(toBuffer(signature), n);
+    signature = convertSignatureToASN1(bufferFromBufferSource(signature), n);
     if (signature === undefined)
       return false;
 

--- a/lib/algorithms/hkdf.js
+++ b/lib/algorithms/hkdf.js
@@ -3,11 +3,11 @@
 const { createHmac } = require('crypto');
 
 const { OperationError, NotSupportedError } = require('../errors');
+const { bufferFromBufferSource } = require('../idl');
 const { kKeyMaterial, CryptoKey } = require('../key');
 const {
   limitUsages,
-  opensslHashFunctionName,
-  toBuffer
+  opensslHashFunctionName
 } = require('../util');
 
 function hmac(hash, key, data) {
@@ -18,21 +18,22 @@ module.exports.HKDF = {
   name: 'HKDF',
 
   deriveBits(params, key, length) {
-    if (length === null || length % 8 !== 0)
+    const hmacKey = bufferFromBufferSource(params.salt);
+    const info = bufferFromBufferSource(params.info);
+
+    if (length === 0 || length % 8 !== 0)
       throw new OperationError();
     length >>= 3;
 
     const hashFn = opensslHashFunctionName(params.hash);
 
     const keyDerivationKey = key[kKeyMaterial];
-    const hmacKey = toBuffer(params.salt);
     const pseudoRandomKey = hmac(hashFn, hmacKey, keyDerivationKey);
     const hashLen = pseudoRandomKey.length;
     const N = Math.ceil(length / hashLen);
 
     const blocks = new Array(N);
     let t = Buffer.alloc(0);
-    const info = toBuffer(params.info);
     for (let i = 0; i < N; i++) {
       const data = Buffer.concat([t, info, Buffer.from([i + 1])],
                                  t.length + info.length + 1);

--- a/lib/algorithms/rsa.js
+++ b/lib/algorithms/rsa.js
@@ -10,8 +10,11 @@ const {
   OperationError
 } = require('../errors');
 const { kKeyMaterial, CryptoKey } = require('../key');
-const { toUnsignedLongEnforceRange } = require('../idl');
-const { limitUsages, opensslHashFunctionName, toBuffer } = require('../util');
+const {
+  toUnsignedLongEnforceRange,
+  bufferFromBufferSource
+} = require('../idl');
+const { limitUsages, opensslHashFunctionName } = require('../util');
 
 const generateKeyPair = promisify(crypto.generateKeyPair);
 
@@ -89,7 +92,7 @@ const rsaBase = {
     };
 
     const opts = {
-      key: toBuffer(keyData),
+      key: bufferFromBufferSource(keyData),
       format: 'der',
       type: keyFormat
     };
@@ -131,12 +134,13 @@ module.exports.RSASSA_PKCS1 = {
 
   sign(algorithm, key, data) {
     const hashFn = opensslHashFunctionName(key.algorithm.hash);
-    return crypto.sign(hashFn, toBuffer(data), key[kKeyMaterial]);
+    return crypto.sign(hashFn, bufferFromBufferSource(data), key[kKeyMaterial]);
   },
 
   verify(algorithm, key, signature, data) {
     const hashFn = opensslHashFunctionName(key.algorithm.hash);
-    return crypto.verify(hashFn, toBuffer(data), key[kKeyMaterial], signature);
+    const dataBuffer = bufferFromBufferSource(data);
+    return crypto.verify(hashFn, dataBuffer, key[kKeyMaterial], signature);
   }
 };
 
@@ -150,7 +154,7 @@ module.exports.RSA_PSS = {
     saltLength = toUnsignedLongEnforceRange(saltLength);
 
     const hashFn = opensslHashFunctionName(key.algorithm.hash);
-    return crypto.sign(hashFn, toBuffer(data), {
+    return crypto.sign(hashFn, bufferFromBufferSource(data), {
       key: key[kKeyMaterial],
       padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
       saltLength
@@ -162,7 +166,7 @@ module.exports.RSA_PSS = {
     saltLength = toUnsignedLongEnforceRange(saltLength);
 
     const hashFn = opensslHashFunctionName(key.algorithm.hash);
-    return crypto.verify(hashFn, toBuffer(data), {
+    return crypto.verify(hashFn, bufferFromBufferSource(data), {
       key: key[kKeyMaterial],
       padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
       saltLength

--- a/lib/idl.js
+++ b/lib/idl.js
@@ -33,6 +33,16 @@ function toUnsignedShortEnforceRange(x) {
   return x >>> 0;
 }
 
+function bufferFromBufferSource(source) {
+  if (ArrayBuffer.isView(source)) {
+    return Buffer.from(source.buffer, source.byteOffset, source.byteLength);
+  } else if (source instanceof ArrayBuffer) {
+    return Buffer.from(source);
+  } else {
+    throw new TypeError();
+  }
+}
+
 function requireDOMString(x) {
   if (typeof x !== 'string')
     throw new TypeError();
@@ -46,5 +56,6 @@ module.exports = {
   toUnsignedShort,
   toUnsignedShortEnforceRange,
 
+  bufferFromBufferSource,
   requireDOMString
 };

--- a/lib/subtle.js
+++ b/lib/subtle.js
@@ -2,9 +2,8 @@
 
 const { getAlgorithm } = require('./algorithms');
 const { InvalidAccessError } = require('./errors');
-const { toBoolean, toUnsignedLong } = require('./idl');
+const { bufferFromBufferSource, toBoolean, toUnsignedLong } = require('./idl');
 const { kAlgorithm, kExtractable, requireKeyUsage } = require('./key');
-const { toBuffer } = require('./util');
 
 // Spec: https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-encrypt
 async function encrypt(algorithm, key, data) {
@@ -13,7 +12,7 @@ async function encrypt(algorithm, key, data) {
     throw new InvalidAccessError();
 
   requireKeyUsage(key, 'encrypt');
-  const buffer = toBuffer(data);
+  const buffer = bufferFromBufferSource(data);
   return alg.encrypt(algorithm, key, buffer);
 }
 
@@ -24,7 +23,7 @@ async function decrypt(algorithm, key, data) {
     throw new InvalidAccessError();
 
   requireKeyUsage(key, 'decrypt');
-  const buffer = toBuffer(data);
+  const buffer = bufferFromBufferSource(data);
   return alg.decrypt(algorithm, key, buffer);
 }
 
@@ -35,7 +34,8 @@ async function sign(algorithm, key, data) {
     throw new InvalidAccessError();
 
   requireKeyUsage(key, 'sign');
-  return alg.sign(algorithm, key, data);
+  const buffer = bufferFromBufferSource(data);
+  return alg.sign(algorithm, key, buffer);
 }
 
 // Spec: https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-verify
@@ -45,12 +45,14 @@ async function verify(algorithm, key, signature, data) {
     throw new InvalidAccessError();
 
   requireKeyUsage(key, 'verify');
-  return alg.verify(algorithm, key, signature, data);
+  const signatureBuffer = bufferFromBufferSource(signature);
+  const dataBuffer = bufferFromBufferSource(data);
+  return alg.verify(algorithm, key, signatureBuffer, dataBuffer);
 }
 
 // Spec: https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-digest
 async function digest(algorithm, data) {
-  const buffer = toBuffer(data);
+  const buffer = bufferFromBufferSource(data);
   const alg = getAlgorithm(algorithm, 'digest');
   return alg.digest(algorithm, buffer);
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,14 +3,6 @@
 const algorithms = require('./algorithms');
 const { DataError } = require('./errors');
 
-module.exports.toBuffer = (source) => {
-  if (ArrayBuffer.isView(source)) {
-    return Buffer.from(source.buffer, source.byteOffset, source.byteLength);
-  } else {
-    return Buffer.from(source);
-  }
-};
-
 function callOp(op) {
   return (algorithm) => algorithms.getAlgorithm(algorithm, op)[op]();
 }


### PR DESCRIPTION
This should ensure that we correctly treat WebIDL `BufferSource` parameters.