### PR TITLE
Fix curve names for OpenSSL

### DIFF
--- a/lib/curves.js
+++ b/lib/curves.js
@@ -6,11 +6,11 @@ module.exports.curveInfo = {
     basePointOrderSize: 32
   },
   'P-384': {
-    internalName: 'prime384v1',
+    internalName: 'secp384r1',
     basePointOrderSize: 48
   },
   'P-521': {
-    internalName: 'prime521v1',
+    internalName: 'secp521r1',
     basePointOrderSize: 66
   }
 };


### PR DESCRIPTION
For some reason, OpenSSL defines prime256v1, but not prime384v1 or prime521v1.

This fixes a few WPTs.