### PR TITLE
Add unsafeExportKey

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const { getAlgorithm } = require('./algorithms');
+
+function unsafeExportKey(format, key) {
+  return getAlgorithm(key.algorithm, 'exportKey').exportKey(format, key);
+}
+
+module.exports = {
+  unsafeExportKey
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { unsafeExportKey } = require('./extensions');
 const { getRandomValues } = require('./random');
 const subtle = require('./subtle');
 const { CryptoKey } = require('./key');
@@ -12,5 +13,8 @@ const crypto = {
 
 module.exports = {
   crypto,
-  CryptoKey
+  CryptoKey,
+
+  // Non-standard extensions
+  unsafeExportKey
 };

--- a/test/unit/default-export.js
+++ b/test/unit/default-export.js
@@ -28,4 +28,10 @@ describe('Default export', () => {
       assert.strictEqual(typeof defExport.CryptoKey, 'function');
     });
   });
+
+  describe('unsafeExportKey function', () => {
+    it('should exist', () => {
+      assert.strictEqual(typeof defExport.unsafeExportKey, 'function');
+    });
+  });
 });

--- a/test/unit/unsafe-export-key.js
+++ b/test/unit/unsafe-export-key.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const assert = require('assert');
+
+const { crypto: { subtle }, unsafeExportKey } = require('../../');
+
+describe('unsafeExportKey', () => {
+  it('should allow exporting non-extractable keys', async () => {
+    const originalKey = await subtle.generateKey(
+      {
+        name: 'AES-CBC',
+        length: 256
+      },
+      false,
+      ['encrypt']
+    );
+
+    assert.rejects(() => {
+      return subtle.exportKey('jwk', originalKey);
+    }, {
+      name: 'InvalidAccessError'
+    });
+
+    const iv = Buffer.alloc(16);
+    const plaintext = Buffer.from('Hello world');
+    const ciphertext = await subtle.encrypt({ name: 'AES-CBC', iv },
+                                            originalKey,
+                                            plaintext);
+
+    const exportedKey = await unsafeExportKey('jwk', originalKey);
+    const restoredKey = await subtle.importKey('jwk',
+                                               exportedKey,
+                                               originalKey.algorithm,
+                                               exportedKey.ext,
+                                               exportedKey.key_ops);
+
+    assert.strictEqual(restoredKey.algorithm.name, 'AES-CBC');
+    assert.strictEqual(restoredKey.algorithm.length, 256);
+    assert.strictEqual(restoredKey.extractable, false);
+    assert.deepStrictEqual(restoredKey.usages, ['encrypt']);
+
+    const newCiphertext = await subtle.encrypt({ name: 'AES-CBC', iv },
+                                               restoredKey,
+                                               plaintext);
+    assert.deepStrictEqual(newCiphertext, ciphertext);
+  });
+});


### PR DESCRIPTION
This adds an exported function `unsafeExportKey` (which cannot be accessed through any of the standardized interfaces, classes, and functions), which allows to export non-extractable keys.

Since all key types (will eventually) support JWK, all keys can be exported as JWK and then imported as usual.

I would appreciate your opinions @panva @sam-github.

Fixes: #13